### PR TITLE
Update AudioTest.asm

### DIFF
--- a/AudioTest.asm
+++ b/AudioTest.asm
@@ -4,13 +4,16 @@
 ORG 0
 ; The lower 4 bits of the audio peripheral output will be incrementing the number of claps by either 1 or 0; the next 4 bits will be the threshold level (1-3)
 Init:
+	CALL Delay ; need to lower the frequency of when SCOMP calls peripheral
 	; Get data from the audio peripheral
-	IN     Sound
+	IN      Sound
 	STORE	Data	; Store the OG data
 	; Display most-significant 10 bits of the magnitude on LEDs
 	AND	Mask
-	ADD	Count
-	STORE	Count
+        ; can add like in to store the count
+	; IN    Count
+	ADD	Count ; don't need
+	STORE	Count ; don't need
 	OUT	Hex0
 	LOAD	Data
 	SHIFT	-4
@@ -19,6 +22,15 @@ Init:
 	OUT	Hex1
 	; GO to the start of the program
 	JUMP   0
+
+; the Delay "function"
+Delay:
+	OUT    Timer
+WaitingLoop:
+	IN     Timer
+	ADDI   -5
+	JNEG   WaitingLoop
+	RETURN
 
 ; Variables
 Count: DW 0


### PR DESCRIPTION
Added a delay, and if I am understanding the peripheral correctly, we don't need to load the count and store it in the SCOMP; we are taking that directly from the peripheral.... Need more help regarding the peripheral sending the count to the SCOMP